### PR TITLE
feat: Create initial Fart Button Android application

### DIFF
--- a/FartButtonApp/app/build.gradle
+++ b/FartButtonApp/app/build.gradle
@@ -1,0 +1,43 @@
+plugins {
+    id 'com.android.application'
+    id 'org.jetbrains.kotlin.android'
+}
+
+android {
+    namespace 'com.example.fartbuttonapp'
+    compileSdk 33
+
+    defaultConfig {
+        applicationId "com.example.fartbuttonapp"
+        minSdk 24
+        targetSdk 33
+        versionCode 1
+        versionName "1.0"
+
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+        }
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
+}
+
+dependencies {
+    implementation 'androidx.core:core-ktx:1.7.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.9.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+}

--- a/FartButtonApp/app/src/main/AndroidManifest.xml
+++ b/FartButtonApp/app/src/main/AndroidManifest.xml
@@ -1,0 +1,20 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.fartbuttonapp">
+
+    <application
+        android:allowBackup="true"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/AppTheme">
+        <activity android:name=".MainActivity"
+                  android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/FartButtonApp/app/src/main/java/com/example/fartbuttonapp/MainActivity.kt
+++ b/FartButtonApp/app/src/main/java/com/example/fartbuttonapp/MainActivity.kt
@@ -1,0 +1,64 @@
+package com.example.fartbuttonapp
+
+import androidx.appcompat.app.AppCompatActivity
+import android.os.Bundle
+import android.util.Log
+import android.widget.Button
+import kotlin.random.Random
+import android.media.MediaPlayer
+
+class MainActivity : AppCompatActivity() {
+    private var mediaPlayer: MediaPlayer? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        val fartButton = findViewById<Button>(R.id.fartButton)
+        val sounds = listOf(
+            R.raw.fart_sound_1,
+            R.raw.fart_sound_2,
+            R.raw.fart_sound_3
+        )
+
+        fartButton.setOnClickListener {
+            if (sounds.isNotEmpty()) {
+                val randomIndex = Random.nextInt(sounds.size)
+                val selectedSoundId = sounds[randomIndex]
+                val selectedSoundName = resources.getResourceEntryName(selectedSoundId)
+                Log.d("MainActivity", "Attempting to play sound: $selectedSoundName (ID: $selectedSoundId)")
+
+                // Release any existing MediaPlayer
+                mediaPlayer?.stop()
+                mediaPlayer?.release()
+                mediaPlayer = null
+
+                mediaPlayer = MediaPlayer.create(this@MainActivity, selectedSoundId)
+
+                if (mediaPlayer == null) {
+                    Log.e("MainActivity", "Error creating MediaPlayer for sound ID: $selectedSoundId. File might be missing or corrupt.")
+                    return@setOnClickListener
+                }
+
+                mediaPlayer?.setOnCompletionListener { mp ->
+                    Log.d("MainActivity", "Sound $selectedSoundName finished playing.")
+                    mp.release()
+                    mediaPlayer = null
+                }
+
+                mediaPlayer?.start()
+                Log.d("MainActivity", "Playing sound: $selectedSoundName")
+            } else {
+                Log.d("MainActivity", "Sound list is empty.")
+            }
+        }
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        Log.d("MainActivity", "onDestroy called. Releasing MediaPlayer.")
+        mediaPlayer?.stop()
+        mediaPlayer?.release()
+        mediaPlayer = null
+    }
+}

--- a/FartButtonApp/app/src/main/res/layout/activity_main.xml
+++ b/FartButtonApp/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MainActivity">
+
+    <Button
+        android:id="@+id/fartButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Press Me!"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/FartButtonApp/app/src/main/res/raw/fart_sound_1.mp3
+++ b/FartButtonApp/app/src/main/res/raw/fart_sound_1.mp3
@@ -1,0 +1,2 @@
+// Placeholder for fart_sound_1.mp3
+// Actual sound data would be here.

--- a/FartButtonApp/app/src/main/res/raw/fart_sound_2.mp3
+++ b/FartButtonApp/app/src/main/res/raw/fart_sound_2.mp3
@@ -1,0 +1,2 @@
+// Placeholder for fart_sound_2.mp3
+// Actual sound data would be here.

--- a/FartButtonApp/app/src/main/res/raw/fart_sound_3.mp3
+++ b/FartButtonApp/app/src/main/res/raw/fart_sound_3.mp3
@@ -1,0 +1,2 @@
+// Placeholder for fart_sound_3.mp3
+// Actual sound data would be here.

--- a/FartButtonApp/build.gradle
+++ b/FartButtonApp/build.gradle
@@ -1,0 +1,10 @@
+// Top-level build file where you can add configuration options common to all sub-projects/modules.
+plugins {
+    id 'com.android.application' version '8.0.0' apply false
+    id 'com.android.library' version '8.0.0' apply false
+    id 'org.jetbrains.kotlin.android' version '1.8.20' apply false
+}
+
+task clean(type: Delete) {
+    delete rootProject.buildDir
+}

--- a/FartButtonApp/settings.gradle
+++ b/FartButtonApp/settings.gradle
@@ -1,0 +1,16 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+rootProject.name = "FartButtonApp"
+include ':app'


### PR DESCRIPTION
Implements a basic Android application with a single button that, when pressed, attempts to play a randomly selected fart sound.

Key features:
- MainActivity with a layout containing a single button.
- Button click listener that randomly selects a sound.
- MediaPlayer logic to play the selected sound.
- Resource management for MediaPlayer to prevent leaks.
- Logging for sound selection and playback attempts.

Note: The sound files included in `app/src/main/res/raw/` (fart_sound_1.mp3, fart_sound_2.mp3, fart_sound_3.mp3) are currently placeholders. To hear actual sounds, you must replace these files with valid audio files. The application is designed to handle the placeholder files gracefully by logging an error and not crashing.